### PR TITLE
update readme: BSP adapter correctly passes the network's link cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BjoinSP-adapter does the conversion in the following order:
       - flow_duration: (flow_size / flow_dr_mean) \* 1000
       - run_duration: taken from the config file
    9. `cpu` = `mem` = `node_capacity` from the network file
-   10. dr=1000: Since the simulator in its current state does not have any link_dr , we are using a high value = 1000
+   10. It gets the NetworkX object from the simulator, including the node and link capacities.
 2. The results of the `place` call from step `1.` above are used to create the placement and schedule for the simulator as follows:
    1. `placement`: The placements are simply obtained from the result of `place` call.
    2. `schedule`: Since BJointSP does not return any schedule we have create it from the flows information returned by `place`. We assume that there is only a single SFC for simplicity. `flows` keeps track of the number of flows forwarded by BJointSP from a source_node to a dest_node. The schedule is created for each `source node`, for each `VNF` in the SFC, for each `destination node`. If a flow exits in `flows` from source node to destination node for a requested VNF we add it to the schedule. We use the probabilities normalization function `normalize_scheduling_probabilities` such that for each SF the sum of Probabilities is 1

--- a/res/networks/triangle.graphml
+++ b/res/networks/triangle.graphml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?><graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <key attr.name="LinkBkwdCap" attr.type="int" for="edge" id="d42" />
   <key attr.name="LinkFwdCap" attr.type="int" for="edge" id="d41" />
   <key attr.name="NodeCap" attr.type="int" for="node" id="d40" />
   <key attr.name="NodeType" attr.type="string" for="node" id="d39" />
@@ -114,7 +113,6 @@
       <data key="d36">c</data>
       <data key="d37">0</data>
       <data key="d41">1024</data>
-      <data key="d42">512</data>
     </edge>
     <edge source="1" target="2">
       <data key="d34">OC-192</data>

--- a/src/adapter/adapter.py
+++ b/src/adapter/adapter.py
@@ -116,7 +116,7 @@ def main():
     # Since the simulator right now does not have any link_dr , we are using a high value = 1000 for now.
     first_result = bjointsp_place(os.path.abspath(args.network),
                                   template, source_list, source_template_object=True, cpu=node_cap, mem=node_cap,
-                                  dr=1000, networkx=simulator.network, write_result=False, logging_level=None)
+                                  networkx=simulator.network, write_result=False, logging_level=None)
     # creating the schedule and placement for the simulator from the first result file that BJointSP returns.
     placement, schedule = get_placement_and_schedule(first_result, nodes_list, sfc_name, sf_list)
 
@@ -131,7 +131,7 @@ def main():
                                                      flow_dr_mean, processing_delay, flow_duration, run_duration)
         if source_exists:
             result = bjointsp_place(os.path.abspath(args.network), template, source, source_template_object=True,
-                                    cpu=node_cap, mem=node_cap, dr=1000, networkx=simulator.network, write_result=False,
+                                    cpu=node_cap, mem=node_cap, networkx=simulator.network, write_result=False,
                                     logging_level=None)
             placement, schedule = get_placement_and_schedule(result, nodes_list, sfc_name, sf_list)
 


### PR DESCRIPTION
It already correctly read the link cap from the NetworkX object, in line with what's defined in the graphml network file.
Passing `dr=1000` to BSP didn't have any effect since we passed the NetworkX object directly; it only does if reading the network from file (as a backup). I removed `dr=1000` and updated the Readme to avoid confusion.

Functionality was correct and remains unchanged.